### PR TITLE
Don't need to write image file to disk

### DIFF
--- a/Snowpark_PyTorch_Image_Rec.ipynb
+++ b/Snowpark_PyTorch_Image_Rec.ipynb
@@ -27,7 +27,7 @@
     "import pandas as pd\n",
     "import json\n",
     "import cachetools\n",
-    "import logging \n",
+    "import logging\n",
     "logger = logging.getLogger(\"snowflake.snowpark.session\")\n",
     "logger.setLevel(logging.ERROR)"
    ]
@@ -46,11 +46,7 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0defcbba-9ae1-4d1e-a44a-28b26cb837d8",
-   "metadata": {},
-   "outputs": [],
+   "cell_type": "raw",
    "source": [
     "# Create Snowflake Session object\n",
     "connection_parameters = json.load(open('connection.json'))\n",
@@ -68,7 +64,10 @@
     "print('Warehouse                   : {}'.format(snowflake_environment[0][5]))\n",
     "print('Snowflake version           : {}'.format(snowflake_environment[0][4]))\n",
     "print('Snowpark for Python version : {}.{}.{}'.format(snowpark_version[0],snowpark_version[1],snowpark_version[2]))"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "attachments": {},
@@ -121,7 +120,7 @@
     "session.add_import('@dash_files/mobilenetv3.py')\n",
     "session.add_import('@dash_files/mobilenetv3-large-1cd25616.pth')\n",
     "\n",
-    "# Add Python packages from Snowflke Anaconda channel\n",
+    "# Add Python packages from Snowflake Anaconda channel\n",
     "session.add_packages('snowflake-snowpark-python','torchvision','joblib','cachetools')\n",
     "\n",
     "@cachetools.cached(cache={})\n",
@@ -165,25 +164,16 @@
     "\n",
     "  return model, transform, cls_idx\n",
     "\n",
-    "def load_image(image_bytes_in_str):\n",
-    "  import os\n",
-    "  image_file = '/tmp/' + str(os.getpid())\n",
-    "  image_bytes_in_hex = bytes.fromhex(image_bytes_in_str)\n",
-    "\n",
-    "  with open(image_file, 'wb') as f:\n",
-    "    f.write(image_bytes_in_hex)\n",
-    "\n",
-    "  return open(image_file, 'rb')\n",
-    "\n",
     "@udf(name='image_recognition_using_bytes',session=session,replace=True,is_permanent=True,stage_location='@dash_files')\n",
     "def image_recognition_using_bytes(image_bytes_in_str: str) -> str:\n",
-    "  import sys\n",
+    "  from io import BytesIO\n",
     "  import torch\n",
     "  from PIL import Image\n",
-    "  import os\n",
+    "\n",
+    "  image_bytes = bytes.fromhex(image_bytes_in_str)\n",
     "\n",
     "  model, transform, cls_idx = load_model()\n",
-    "  img = Image.open(load_image(image_bytes_in_str)).convert('RGB')\n",
+    "  img = Image.open(BytesIO(image_bytes)).convert('RGB')\n",
     "  img = transform(img).unsqueeze(0)\n",
     "\n",
     "  # Get model output and human text prediction\n",
@@ -203,7 +193,7 @@
    "id": "ab629365",
    "metadata": {},
    "source": [
-    "*NOTE: This UDF is called from [Snowpark_PyTorch_Streamlit_Upload_Image_Rec](Snowpark_PyTorch_Streamlit_Upload_Image_Rec.py) and [Snowpark_PyTorch_Streamlit_OpenAI_Image_Rec](Snowpark_PyTorch_Streamlit_OpenAI_Image_Rec.py) Streamlit apps.*"
+    "*NOTE: This UDF is called from [Snowpark_PyTorch_Streamlit_Upload_Image_Rec](Snowpark_PyTorch_Streamlit_Upload_Image_Rec.py) and [Snowpark_PyTorch_Streamlit_OpenAI_Image_Rec](Snowpark_PyTorch_Streamlit_OpenAI_Image_Rec.py) Streamlit apps.*\n"
    ]
   }
  ],


### PR DESCRIPTION
Hi @iamontheinet - writing the image to disk and reading it back in `load_image()` seemed unnecessary, so I replaced that step with simply decoding the hex and using `BytesIO` to turn the bytes into a stream for consumption by `Image.open()`.

Tested, and it works just the same.